### PR TITLE
Scorecard is now scrollable

### DIFF
--- a/frontend/src/components/Scorecard.vue
+++ b/frontend/src/components/Scorecard.vue
@@ -119,7 +119,9 @@ export default {
   margin-left: auto;
   margin-right: auto;
   width: 66%;
+  height: 66%;
   color: var(--blue);
+  overflow-y: scroll;
 }
 
 h1,


### PR DESCRIPTION
Scorecard is now scrollable. Based on my research for overflow: scroll to work it needs fixed dimensions. Could be wrong, because my CSS skills aren't good. 
Sadly change creates unneeded whitespace. 
When using fixed dimensions centering the scorecard in the middle of the screen might be an option for visual improvements.