### PR TITLE
Fixes #26: Scorecard Problem on Wedding

### DIFF
--- a/frontend/src/models/scorecard.js
+++ b/frontend/src/models/scorecard.js
@@ -12,8 +12,8 @@ export class Scorecard {
     const points = score.totalPoints();
     this.players.forEach(p => {
       newTotalPoints[p.id] = includes(winningPlayers, p)
-        ? this.totalPointsFor(p) + points
-        : this.totalPointsFor(p) - points;
+        ? this.totalPointsFor(p) + points * (winningPlayers.length === 1 ? 3 : 1)
+        : this.totalPointsFor(p) - points * (winningPlayers.length === 3 ? 3 : 1)
     });
 
     const scoreline = new Scoreline(newTotalPoints, winningPlayers, points);

--- a/frontend/tests/unit/models/scorecard.test.js
+++ b/frontend/tests/unit/models/scorecard.test.js
@@ -43,6 +43,42 @@ describe("Scorecard", () => {
     expect(scorecard.scoreLines[0].totalPoints[players[2].id]).toEqual(-4);
   });
 
+  test("should calculate winning solo score line", () => {
+    scorecard.addScore(
+      new ScoreBuilder()
+        .withWinners(re, players[0])
+        .withLosers(kontra, players[1], players[2], players[3])
+        .withPoints(4)
+        .build()
+    );
+
+    expect(scorecard.scoreLines[0]).toBeDefined();
+    expect(scorecard.scoreLines[0].points).toEqual(4);
+    expect(scorecard.scoreLines[0].winners).toEqual([players[0]]);
+    expect(scorecard.scoreLines[0].totalPoints[players[1].id]).toEqual(-4);
+    expect(scorecard.scoreLines[0].totalPoints[players[2].id]).toEqual(-4);
+    expect(scorecard.scoreLines[0].totalPoints[players[3].id]).toEqual(-4);
+    expect(scorecard.scoreLines[0].totalPoints[players[0].id]).toEqual(12);
+  });
+
+  test("should calculate loosing solo score line", () => {
+    scorecard.addScore(
+      new ScoreBuilder()
+        .withWinners(re, players[1], players[2], players[3])
+        .withLosers(kontra, players[0])
+        .withPoints(4)
+        .build()
+    );
+
+    expect(scorecard.scoreLines[0]).toBeDefined();
+    expect(scorecard.scoreLines[0].points).toEqual(4);
+    expect(scorecard.scoreLines[0].winners).toEqual([players[1], players[2], players[3]]);
+    expect(scorecard.scoreLines[0].totalPoints[players[0].id]).toEqual(-12);
+    expect(scorecard.scoreLines[0].totalPoints[players[1].id]).toEqual(4);
+    expect(scorecard.scoreLines[0].totalPoints[players[2].id]).toEqual(4);
+    expect(scorecard.scoreLines[0].totalPoints[players[3].id]).toEqual(4);
+  });
+
   test("should calculate final scores", () => {
     scorecard.addScore(
       new ScoreBuilder()


### PR DESCRIPTION
This commit will solve the calculation for any kind of solo played.

Please have a look at the second test `should calculate loosing solo score line` I wrote. The ScoreBuilder helper needs the winning team to be "re".
```javascript
new ScoreBuilder()
    .withWinners(re, players[1], players[2], players[3])
    .withLosers(kontra, players[0])
```
If I swap the teamname - (it shouldn't make any difference though) `expect(scorecard.scoreLines[0].winners)` will return `player[0]`, who actually lost the game. I couldn't figure out why.