### PR TITLE
Rule based AI - fehlRule

### DIFF
--- a/frontend/src/components/Card.vue
+++ b/frontend/src/components/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="card" :class="[positionClasses, zIndex]">
+  <div class="card" :class="[positionClasses]">
     <template v-if="card">
       <div class="card-inner" :class="cardClasses">
         <template v-if="isCovered">
@@ -129,22 +129,6 @@ export default {
   top: -10px;
   box-shadow: 0 20px 38px rgba(0, 0, 0, 0.25), 0 15px 12px rgba(0, 0, 0, 0.22);
   z-index: var(--card-selected-layer);
-}
-
-.first-card {
-  z-index: var(--card-first-layer);
-}
-
-.second-card {
-  z-index: var(--card-second-layer);
-}
-
-.third-card {
-  z-index: var(--card-third-layer);
-}
-
-.fourth-card {
-  z-index: var(--card-fourth-layer);
 }
 
 .card-top {

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -71,7 +71,7 @@ export class RuleBasedBehaviour {
     if (hand.hasNonTrumps(baseCard.suit)) {
       let nonTrumpCards = hand.nonTrumps(baseCard.suit);
       let highest = nonTrumpCards[0];
-      let lowest = nonTrumpCards.reverse()[0];
+      let lowest = nonTrumpCards.slice(-1)[0];
 
       if (memory.nonTrumpSuitPlayedBefore(baseCard.suit)) {
         return lowest;

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -3,14 +3,14 @@ import { playableCards } from "@/models/playableCardFinder";
 import { chance } from "@/models/random";
 
 export class HighestCardBehavior {
-  cardToPlay(hand, baseCard) {
-    return playableCards(hand.cards, baseCard)[0];
+  cardToPlay(hand, trick, memory) {
+    return playableCards(hand.cards, trick.baseCard())[0];
   }
 }
 
 export class RandomCardBehavior {
-  cardToPlay(hand, baseCard) {
-    return sample(playableCards(hand.cards, baseCard));
+  cardToPlay(hand, trick, memory) {
+    return sample(playableCards(hand.cards, trick.baseCard()));
   }
 
   announcementToMake(possibleAnnouncements) {

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -86,48 +86,38 @@ export class RuleBasedBehaviour {
 
       return lowest;
     } else {
-      let hUtils = new HandUtils(hand);
-      let usefulTrump = hUtils.getUsefulTrumpFornonTrumpTrick(trick);
+      let usefulTrump = this.getUsefulTrumpForNonTrumpTrick(hand, trick);
       return usefulTrump
         ? usefulTrump
         : sample(playableCards(hand.cards, undefined));
     }
   }
-}
 
-/**
- * This class contains biased opinions, therefore it's not part of hand
- */
-export class HandUtils {
-  constructor(hand) {
-    this.hand = hand;
-  }
-
-  getUsefulTrumpFornonTrumpTrick(trick) {
+  getUsefulTrumpForNonTrumpTrick(hand, trick) {
     /**
      * In case ace or other high card is already lying,
      * we still want to win the trick if possible
      */
-    let sortedList = this.getUsefulTrumpListFornonTrumpTrick();
+    let sortedList = this.getUsefulTrumpListForNonTrumpTrick(hand);
     for (let index = 0; index < sortedList.length; index++) {
       if (trick.highestCard().card.compareTo(sortedList[index]) > 0)
         return sortedList[index];
     }
   }
 
-  getUsefulTrumpListFornonTrumpTrick() {
+  getUsefulTrumpListForNonTrumpTrick(hand) {
     /**
      * We want to build a good good trump order and return the best card
      * [Fox, ten of diamonds, Jack of diamonds ... ten of hearts]
      */
     let trumpOrder = [];
     trumpOrder = trumpOrder.concat(
-      this.hand.cards.filter(
+      hand.cards.filter(
         card => card.suit === suits.diamonds && card.value > 10
       )
     );
     trumpOrder = trumpOrder.concat(
-      this.hand.cards
+      hand.cards
         .filter(card => card.isTrump() && card.value !== 4)
         .reverse()
     );

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -87,8 +87,8 @@ export class RuleBasedBehaviour {
 
     if (
       trick.highestCard().card.value < highest.value &&
-      highest.value === 11 &&
-      nonTrumpCards.length < 4
+      highest.rank === ranks.ace &&
+      nonTrumpCards.length < trick.expectedNumberOfCards
     ) {
       return highest;
     }

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -48,7 +48,6 @@ export class RuleBasedBehaviour {
       return this.startingRule(hand, memory);
     }
     if (!baseCard.isTrump()) {
-      /** We need to serve a non-trump card */
       return this.nonTrumpRule(hand, trick, memory);
     }
     // ToDo how to play if not starting or mustn't serve nonTrump
@@ -75,17 +74,17 @@ export class RuleBasedBehaviour {
 
       if (memory.nonTrumpSuitPlayedBefore(baseCard.suit)) {
         return lowest;
-      } else {
-        if (
-          trick.highestCard().card.value < highest.value &&
-          highest.value === 11 &&
-          nonTrumpCards.length < 4
-        ) {
-          return highest;
-        } else {
-          return lowest;
-        }
       }
+
+      if (
+        trick.highestCard().card.value < highest.value &&
+        highest.value === 11 &&
+        nonTrumpCards.length < 4
+      ) {
+        return highest;
+      }
+
+      return lowest;
     } else {
       let hUtils = new HandUtils(hand);
       let usefulTrump = hUtils.getUsefulTrumpFornonTrumpTrick(trick);

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -26,3 +26,34 @@ export class RandomCardBehavior {
     return null;
   }
 }
+
+export class BasicRuleBasedBehaviour {
+  cardToPlay(hand, baseCard) {
+    if (!baseCard.isTrump()){
+      return this.fehlRule(hand, baseCard);
+    }
+    return sample(playableCards(hand.cards, baseCard));
+  }
+
+  /*
+    needs to know if own card is higher than highest in trick.
+    Therefore we need to know the current trick
+  */
+  fehlRule(hand, baseCard){
+    fehlCards = hand.cards.filter(card => card.suits === basecard.suits)
+    if (fehlCards.length > 0){
+      highestFehl = fehlcards[0]
+      if (fehlCards.length > 0) {
+        if (baseCard.value() < highestFehl.value() && highestFehl.value() === 11){
+          return highestFehl;
+        }else{
+          return fehlcards.reverse()[0]
+        }
+      }
+    }else{
+      // play trump. usually use high-value cards
+      trumpCards = hand.cards.filter(card => card.isTrump() === true)
+      return sample(trumpCards)
+    }
+  }
+}

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -59,7 +59,7 @@ export class RuleBasedBehaviour {
   startingRule(hand, memory) {
     for (const suit of [suits.clubs, suits.spades, suits.hearts]) {
       if (hand.hasBlankAce(suit) && !memory.nonTrumpSuitPlayedBefore(suit)) {
-        return hand.nonTrumpCardsBySuit(suit)[0];
+        return hand.nonTrumps(suit)[0];
       }
     }
     // ToDo check if we know with whom we play and if we want to play a strategy
@@ -68,8 +68,8 @@ export class RuleBasedBehaviour {
 
   nonTrumpRule(hand, trick, memory) {
     let baseCard = trick.baseCard();
-    if (hand.mustServeSuit(baseCard.suit)) {
-      let nonTrumpCards = hand.nonTrumpCardsBySuit(baseCard.suit);
+    if (hand.hasNonTrumps(baseCard.suit)) {
+      let nonTrumpCards = hand.nonTrumps(baseCard.suit);
       let highest = nonTrumpCards[0];
       let lowest = nonTrumpCards.reverse()[0];
 

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -52,11 +52,17 @@ export class BasicRuleBasedBehaviour {
       return this.fehlRule(hand, trick, memory);
     }
     // ToDo how to play if not starting or mustn't serve fehl
+    // i'm thinking of something working with expectation value
     return sample(playableCards(hand.cards, baseCard));
   }
 
   startingRule(hand, memory) {
-    // ToDo needs to check if good Fehlcard is available. Currently will only play random card
+    for (const suit of [suits.clubs, suits.spades, suits.hearts]) {
+      if (hand.hasBlankAce(suit) && !memory.fehlSuitPlayedBefore(suit)) {
+        return hand.fehlCardsBySuit(suit)[0];
+      }
+    }
+    // ToDo check if we know with whom we play and if we want to play a strategy
     return sample(playableCards(hand.cards, undefined));
   }
 

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -28,7 +28,7 @@ export class RandomCardBehavior {
   }
 }
 
-export class BasicRuleBasedBehaviour {
+export class RuleBasedBehaviour {
   announcementToMake(possibleAnnouncements) {
     // ToDo announce by "goodies"
     /**

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -30,8 +30,9 @@ export class RandomCardBehavior {
 
 export class BasicRuleBasedBehaviour {
   announcementToMake(possibleAnnouncements) {
-    // ToDo
-    /** announce by "goodies". for instance
+    // ToDo announce by "goodies"
+    /**
+     * for instance
      * only one fehlsuit
      * high number of trumps
      * high trumps, such as 2x ten of hearts
@@ -66,7 +67,7 @@ export class BasicRuleBasedBehaviour {
       let highest = fehlCards[0];
       let lowest = fehlCards.reverse()[0];
 
-      if (memory.fehlSuitPlayedBefore()) {
+      if (memory.fehlSuitPlayedBefore(baseCard.suit)) {
         return lowest;
       } else {
         if (

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -1,6 +1,7 @@
 import { sample } from "lodash-es";
 import { playableCards } from "@/models/playableCardFinder";
 import { chance } from "@/models/random";
+import { suits } from "./card";
 
 export class HighestCardBehavior {
   cardToPlay(hand, trick, memory) {
@@ -28,32 +29,102 @@ export class RandomCardBehavior {
 }
 
 export class BasicRuleBasedBehaviour {
-  cardToPlay(hand, baseCard) {
-    if (!baseCard.isTrump()){
-      return this.fehlRule(hand, baseCard);
+  announcementToMake(possibleAnnouncements) {
+    // ToDo
+    /** announce by "goodies". for instance
+     * only one fehlsuit
+     * high number of trumps
+     * high trumps, such as 2x ten of hearts
+     * blank ace and starting
+     */
+    return null;
+  }
+
+  cardToPlay(hand, trick, memory) {
+    let baseCard = trick.baseCard();
+    if (!baseCard) {
+      /** It's our turn. Decide how to deal with cards */
+      return this.startingRule(hand, memory);
     }
+    if (!baseCard.isTrump()) {
+      /** We need to serve a fehl card */
+      return this.fehlRule(hand, trick, memory);
+    }
+    // ToDo how to play if not starting or mustn't serve fehl
     return sample(playableCards(hand.cards, baseCard));
   }
 
-  /*
-    needs to know if own card is higher than highest in trick.
-    Therefore we need to know the current trick
-  */
-  fehlRule(hand, baseCard){
-    fehlCards = hand.cards.filter(card => card.suits === basecard.suits)
-    if (fehlCards.length > 0){
-      highestFehl = fehlcards[0]
-      if (fehlCards.length > 0) {
-        if (baseCard.value() < highestFehl.value() && highestFehl.value() === 11){
-          return highestFehl;
-        }else{
-          return fehlcards.reverse()[0]
+  startingRule(hand, memory) {
+    // ToDo needs to check if good Fehlcard is available. Currently will only play random card
+    return sample(playableCards(hand.cards, undefined));
+  }
+
+  fehlRule(hand, trick, memory) {
+    let baseCard = trick.baseCard();
+    if (hand.mustServeSuit(baseCard.suit)) {
+      let fehlCards = hand.fehlCardsBySuit(baseCard.suit);
+      let highest = fehlCards[0];
+      let lowest = fehlCards.reverse()[0];
+
+      if (memory.fehlSuitPlayedBefore()) {
+        return lowest;
+      } else {
+        if (
+          trick.highestCard().card.value < highest.value &&
+          highest.value === 11 &&
+          fehlCards.length < 4
+        ) {
+          return highest;
+        } else {
+          return lowest;
         }
       }
-    }else{
-      // play trump. usually use high-value cards
-      trumpCards = hand.cards.filter(card => card.isTrump() === true)
-      return sample(trumpCards)
+    } else {
+      let hUtils = new HandUtils(hand);
+      let usefulTrump = hUtils.getUsefulTrumpForFehlTrick(trick);
+      return usefulTrump
+        ? usefulTrump
+        : sample(playableCards(hand.cards, undefined));
     }
+  }
+}
+
+/**
+ * This class contains biased opinions, therefore it's not part of hand
+ */
+export class HandUtils {
+  constructor(hand) {
+    this.hand = hand;
+  }
+
+  getUsefulTrumpForFehlTrick(trick) {
+    /**
+     * In case ace or other high card is already lying,
+     * we still want to win the trick if possible
+     */
+    let sortedList = this.getUsefulTrumpListForFehlTrick();
+    for (let index = 0; index < sortedList.length; index++) {
+      if (trick.highestCard().card.compareTo(sortedList[index]) > 0)
+        return sortedList[index];
+    }
+  }
+
+  getUsefulTrumpListForFehlTrick() {
+    /**
+     * We want to build a good good trump order and return the best card
+     * [Fox, ten of diamonds, Jack of diamonds ... ten of hearts]
+     */
+    let trumpOrder = [];
+    trumpOrder = trumpOrder.concat(
+      this.hand.cards.filter(
+        card => card.suit === suits.diamonds && card.value > 10
+      )
+    );
+    trumpOrder = trumpOrder.concat(
+      this.hand.cards
+        .filter(card => card.isTrump() && card.value !== 4)
+        .reverse()
+    );
+    return trumpOrder;
   }
 }

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -68,29 +68,33 @@ export class RuleBasedBehaviour {
   nonTrumpRule(hand, trick, memory) {
     let baseCard = trick.baseCard();
     if (hand.hasNonTrumps(baseCard.suit)) {
-      let nonTrumpCards = hand.nonTrumps(baseCard.suit);
-      let highest = nonTrumpCards[0];
-      let lowest = nonTrumpCards.slice(-1)[0];
-
-      if (memory.nonTrumpSuitPlayedBefore(baseCard.suit)) {
-        return lowest;
-      }
-
-      if (
-        trick.highestCard().card.value < highest.value &&
-        highest.value === 11 &&
-        nonTrumpCards.length < 4
-      ) {
-        return highest;
-      }
-
-      return lowest;
+      return this.serveNonTrump(hand, trick, memory);
     } else {
       let usefulTrump = this.getUsefulTrumpForNonTrumpTrick(hand, trick);
       return usefulTrump
         ? usefulTrump
         : sample(playableCards(hand.cards, undefined));
     }
+  }
+
+  serveNonTrump(hand, trick, memory) {
+    let nonTrumpCards = hand.nonTrumps(trick.baseCard().suit);
+    let highest = nonTrumpCards[0];
+    let lowest = nonTrumpCards.slice(-1)[0];
+
+    if (memory.nonTrumpSuitPlayedBefore(trick.baseCard().suit)) {
+      return lowest;
+    }
+
+    if (
+      trick.highestCard().card.value < highest.value &&
+      highest.value === 11 &&
+      nonTrumpCards.length < 4
+    ) {
+      return highest;
+    }
+
+    return lowest;
   }
 
   getUsefulTrumpForNonTrumpTrick(hand, trick) {

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -33,7 +33,7 @@ export class RuleBasedBehaviour {
     // ToDo announce by "goodies"
     /**
      * for instance
-     * only one fehlsuit
+     * only one nonTrumpsuit
      * high number of trumps
      * high trumps, such as 2x ten of hearts
      * blank ace and starting
@@ -48,38 +48,38 @@ export class RuleBasedBehaviour {
       return this.startingRule(hand, memory);
     }
     if (!baseCard.isTrump()) {
-      /** We need to serve a fehl card */
-      return this.fehlRule(hand, trick, memory);
+      /** We need to serve a non-trump card */
+      return this.nonTrumpRule(hand, trick, memory);
     }
-    // ToDo how to play if not starting or mustn't serve fehl
+    // ToDo how to play if not starting or mustn't serve nonTrump
     // i'm thinking of something working with expectation value
     return sample(playableCards(hand.cards, baseCard));
   }
 
   startingRule(hand, memory) {
     for (const suit of [suits.clubs, suits.spades, suits.hearts]) {
-      if (hand.hasBlankAce(suit) && !memory.fehlSuitPlayedBefore(suit)) {
-        return hand.fehlCardsBySuit(suit)[0];
+      if (hand.hasBlankAce(suit) && !memory.nonTrumpSuitPlayedBefore(suit)) {
+        return hand.nonTrumpCardsBySuit(suit)[0];
       }
     }
     // ToDo check if we know with whom we play and if we want to play a strategy
     return sample(playableCards(hand.cards, null));
   }
 
-  fehlRule(hand, trick, memory) {
+  nonTrumpRule(hand, trick, memory) {
     let baseCard = trick.baseCard();
     if (hand.mustServeSuit(baseCard.suit)) {
-      let fehlCards = hand.fehlCardsBySuit(baseCard.suit);
-      let highest = fehlCards[0];
-      let lowest = fehlCards.reverse()[0];
+      let nonTrumpCards = hand.nonTrumpCardsBySuit(baseCard.suit);
+      let highest = nonTrumpCards[0];
+      let lowest = nonTrumpCards.reverse()[0];
 
-      if (memory.fehlSuitPlayedBefore(baseCard.suit)) {
+      if (memory.nonTrumpSuitPlayedBefore(baseCard.suit)) {
         return lowest;
       } else {
         if (
           trick.highestCard().card.value < highest.value &&
           highest.value === 11 &&
-          fehlCards.length < 4
+          nonTrumpCards.length < 4
         ) {
           return highest;
         } else {
@@ -88,7 +88,7 @@ export class RuleBasedBehaviour {
       }
     } else {
       let hUtils = new HandUtils(hand);
-      let usefulTrump = hUtils.getUsefulTrumpForFehlTrick(trick);
+      let usefulTrump = hUtils.getUsefulTrumpFornonTrumpTrick(trick);
       return usefulTrump
         ? usefulTrump
         : sample(playableCards(hand.cards, undefined));
@@ -104,19 +104,19 @@ export class HandUtils {
     this.hand = hand;
   }
 
-  getUsefulTrumpForFehlTrick(trick) {
+  getUsefulTrumpFornonTrumpTrick(trick) {
     /**
      * In case ace or other high card is already lying,
      * we still want to win the trick if possible
      */
-    let sortedList = this.getUsefulTrumpListForFehlTrick();
+    let sortedList = this.getUsefulTrumpListFornonTrumpTrick();
     for (let index = 0; index < sortedList.length; index++) {
       if (trick.highestCard().card.compareTo(sortedList[index]) > 0)
         return sortedList[index];
     }
   }
 
-  getUsefulTrumpListForFehlTrick() {
+  getUsefulTrumpListFornonTrumpTrick() {
     /**
      * We want to build a good good trump order and return the best card
      * [Fox, ten of diamonds, Jack of diamonds ... ten of hearts]

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -71,7 +71,7 @@ export class RuleBasedBehaviour {
     if (hand.hasNonTrumps(baseCard.suit)) {
       return this.serveNonTrump(hand, trick, memory);
     } else {
-      let usefulTrump = this.getUsefulTrumpForNonTrumpTrick(hand, trick);
+      let usefulTrump = this.findMostValuableWinningTrump(hand, trick);
       return usefulTrump ?? sample(playableCards(hand.cards, null));
     }
   }
@@ -116,37 +116,6 @@ export class RuleBasedBehaviour {
       ...hand.trumps().reverse()
     ];
 
-    return trumpPreference.find(card => card.beats(highestCard)) ?? null;
-  }
-
-  getUsefulTrumpForNonTrumpTrick(hand, trick) {
-    /**
-     * In case ace or other high card is already lying,
-     * we still want to win the trick if possible
-     */
-    let sortedList = this.getUsefulTrumpListForNonTrumpTrick(hand);
-    for (let index = 0; index < sortedList.length; index++) {
-      if (trick.highestCard().card.compareTo(sortedList[index]) > 0)
-        return sortedList[index];
-    }
-  }
-
-  getUsefulTrumpListForNonTrumpTrick(hand) {
-    /**
-     * We want to build a good good trump order and return the best card
-     * [Fox, ten of diamonds, Jack of diamonds ... ten of hearts]
-     */
-    let trumpOrder = [];
-    trumpOrder = trumpOrder.concat(
-      hand.cards.filter(
-        card => card.suit === suits.diamonds && card.value > 10
-      )
-    );
-    trumpOrder = trumpOrder.concat(
-      hand.cards
-        .filter(card => card.isTrump() && card.value !== 4)
-        .reverse()
-    );
-    return trumpOrder;
+    return trumpPreference.find(card => card && card.beats(highestCard)) ?? null;
   }
 }

--- a/frontend/src/models/behaviors.js
+++ b/frontend/src/models/behaviors.js
@@ -63,7 +63,7 @@ export class RuleBasedBehaviour {
       }
     }
     // ToDo check if we know with whom we play and if we want to play a strategy
-    return sample(playableCards(hand.cards, undefined));
+    return sample(playableCards(hand.cards, null));
   }
 
   fehlRule(hand, trick, memory) {

--- a/frontend/src/models/card.js
+++ b/frontend/src/models/card.js
@@ -78,6 +78,10 @@ export class Card {
     return "";
   }
 
+  beats(anotherCard) {
+    return this.compareTo(anotherCard) < 0;
+  }
+
   compareTo(anotherCard) {
     const thisIsTrump = this.isTrump();
     const otherCardIsTrump = anotherCard.isTrump();

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -49,14 +49,14 @@ export class Hand {
     );
   }
 
-  nonTrumpCardsBySuit(suit) {
+  nonTrumps(suit) {
     return this.cards.filter(
       card => card.suit === suit && card.isTrump() === false
     );
   }
 
-  mustServeSuit(suit) {
-    return this.nonTrumpCardsBySuit(suit).length > 0;
+  hasNonTrumps(suit) {
+    return this.nonTrumps(suit).length > 0;
   }
 
   trumps() {
@@ -68,7 +68,7 @@ export class Hand {
   }
 
   getBlankAce(suit) {
-    let nonTrumpCards = this.nonTrumpCardsBySuit(suit);
+    let nonTrumpCards = this.nonTrumps(suit);
     return nonTrumpCards.length === 1 && nonTrumpCards[0].value === 11
       ? nonTrumpCards[0]
       : undefined;

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -1,6 +1,5 @@
-import { suits, ranks, compare } from "@/models/card";
+import { suits, ranks, compare, jack } from "@/models/card";
 import { find, without } from "lodash-es";
-import { jack } from "./card";
 
 export class Hand {
   constructor(cards = []) {
@@ -55,7 +54,7 @@ export class Hand {
 
   nonTrumps(suit) {
     return this.cards.filter(
-      card => card.suit === suit && card.isTrump() === false
+      card => card.suit === suit && !card.isTrump()
     );
   }
 
@@ -64,7 +63,7 @@ export class Hand {
   }
 
   trumps() {
-    return this.cards.filter(card => card.isTrump() === true);
+    return this.cards.filter(card => card.isTrump());
   }
 
   hasTrumps() {
@@ -73,9 +72,9 @@ export class Hand {
 
   getBlankAce(suit) {
     let nonTrumpCards = this.nonTrumps(suit);
-    return nonTrumpCards.length === 1 && nonTrumpCards[0].value === 11
+    return nonTrumpCards.length === 1 && nonTrumpCards[0].rank === ranks.ace
       ? nonTrumpCards[0]
-      : undefined;
+      : null;
   }
 
   hasBlankAce(suit) {

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -48,4 +48,23 @@ export class Hand {
       this.highest().compareTo(jack.of(suits.diamonds)) < 0
     );
   }
+
+  fehlCardsBySuit(suit) {
+    return this.cards.filter(
+      card => card.suit === suit && card.isTrump() === false
+    );
+  }
+
+  mustServeSuit(suit) {
+    return this.fehlCardsBySuit(suit).length > 0;
+  }
+
+  trumps() {
+    return this.cards.filter(card => card.isTrump() === true);
+  }
+
+  hasBlankAce(suit) {
+    let fehlCards = this.fehlCardsBySuit(suit);
+    return fehlCards.length === 1 && fehlCards[0].value === 11;
+  }
 }

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -25,6 +25,10 @@ export class Hand {
     return find(this.cards, card);
   }
 
+  highest() {
+    return this.cards[0];
+  }
+
   remove(card) {
     if (!this.find(card)) {
       throw new Error("can't remove card that isn't on hand");
@@ -41,7 +45,7 @@ export class Hand {
     return (
       this.cards.filter(card => card.rank === ranks.king).length < 5 &&
       this.cards.filter(card => card.value >= 10).length < 7 &&
-      this.cards[0].compareTo(jack.of(suits.diamonds)) < 0
+      this.highest().compareTo(jack.of(suits.diamonds)) < 0
     );
   }
 }

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -1,6 +1,6 @@
 import { suits, ranks, compare } from "@/models/card";
 import { find, without } from "lodash-es";
-import { Card, jack } from "./card";
+import { jack } from "./card";
 
 export class Hand {
   constructor(cards = []) {

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -63,8 +63,24 @@ export class Hand {
     return this.cards.filter(card => card.isTrump() === true);
   }
 
-  hasBlankAce(suit) {
+  getBlankAce(suit) {
     let fehlCards = this.fehlCardsBySuit(suit);
-    return fehlCards.length === 1 && fehlCards[0].value === 11;
+    return fehlCards.length === 1 && fehlCards[0].value === 11
+      ? fehlCards[0]
+      : undefined;
+  }
+
+  hasBlankAce(suit) {
+    return this.getBlankAce(suit) ? true : false;
+  }
+
+  getBlankAces() {
+    let aces = [];
+    [suits.clubs, suits.spades, suits.hearts].forEach(suit => {
+      let ace = this.getBlankAce(suit);
+      if (ace) aces.push(ace);
+    });
+    return aces;
+    //this.cards.filter(card => !card.isTrump() && card.value === 11);
   }
 }

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -63,6 +63,10 @@ export class Hand {
     return this.cards.filter(card => card.isTrump() === true);
   }
 
+  hasTrumps() {
+    return this.trumps().length > 0;
+  }
+
   getBlankAce(suit) {
     let fehlCards = this.fehlCardsBySuit(suit);
     return fehlCards.length === 1 && fehlCards[0].value === 11

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -25,6 +25,10 @@ export class Hand {
     return find(this.cards, card);
   }
 
+  findAny(suit, rank) {
+    return find(this.cards, { suit, rank });
+  }
+
   highest() {
     return this.cards[0];
   }

--- a/frontend/src/models/hand.js
+++ b/frontend/src/models/hand.js
@@ -49,14 +49,14 @@ export class Hand {
     );
   }
 
-  fehlCardsBySuit(suit) {
+  nonTrumpCardsBySuit(suit) {
     return this.cards.filter(
       card => card.suit === suit && card.isTrump() === false
     );
   }
 
   mustServeSuit(suit) {
-    return this.fehlCardsBySuit(suit).length > 0;
+    return this.nonTrumpCardsBySuit(suit).length > 0;
   }
 
   trumps() {
@@ -68,9 +68,9 @@ export class Hand {
   }
 
   getBlankAce(suit) {
-    let fehlCards = this.fehlCardsBySuit(suit);
-    return fehlCards.length === 1 && fehlCards[0].value === 11
-      ? fehlCards[0]
+    let nonTrumpCards = this.nonTrumpCardsBySuit(suit);
+    return nonTrumpCards.length === 1 && nonTrumpCards[0].value === 11
+      ? nonTrumpCards[0]
       : undefined;
   }
 

--- a/frontend/src/models/memory.js
+++ b/frontend/src/models/memory.js
@@ -10,7 +10,7 @@ export class PercentageMemory {
   constructor(percent) {
     this.percent = percent;
     this.playedCards = [];
-    this.id = uniqueId("memory_percent");
+    this.id = uniqueId("memory_percent_");
   }
 
   memorize(playedCard) {
@@ -21,7 +21,7 @@ export class PercentageMemory {
 export class PerfectMemory {
   constructor() {
     this.playedCards = [];
-    this.id = uniqueId("memory_perfect");
+    this.id = uniqueId("memory_perfect_");
   }
 
   memorize(playedCard) {
@@ -32,7 +32,7 @@ export class PerfectMemory {
 export class PriorityMemory {
   constructor() {
     this.playedCards = [];
-    this.id = uniqueId("memory_priority");
+    this.id = uniqueId("memory_priority_");
   }
 
   memorize(playedCard) {
@@ -41,8 +41,7 @@ export class PriorityMemory {
     Will memorize all by value
     Queens, Tens, Aces
     */
-    if ([3, 10, 11].includes(playedCard.card.value)) {
+    if ([3, 10, 11].includes(playedCard.card.value))
       this.playedCards.push(playedCard);
-    }
   }
 }

--- a/frontend/src/models/memory.js
+++ b/frontend/src/models/memory.js
@@ -1,0 +1,48 @@
+import { uniqueId } from "lodash-es";
+
+/**
+ * I would love some kind of interface here.
+ * Interface.js seems to be a reasonable possibility.
+ * Right now we'll stick to this.
+ */
+
+export class PercentageMemory {
+  constructor(percent) {
+    this.percent = percent;
+    this.playedCards = [];
+    this.id = uniqueId("memory_percent");
+  }
+
+  memorize(playedCard) {
+    if (Math.random() <= this.percent) this.playedCards.push(playedCard);
+  }
+}
+
+export class PerfectMemory {
+  constructor() {
+    this.playedCards = [];
+    this.id = uniqueId("memory_perfect");
+  }
+
+  memorize(playedCard) {
+    this.playedCards.push(playedCard);
+  }
+}
+
+export class PriorityMemory {
+  constructor() {
+    this.playedCards = [];
+    this.id = uniqueId("memory_priority");
+  }
+
+  memorize(playedCard) {
+    /*
+    Superb function to take care of 'important' cards
+    Will memorize all by value
+    Queens, Tens, Aces
+    */
+    if ([3, 10, 11].includes(playedCard.card.value)) {
+      this.playedCards.push(playedCard);
+    }
+  }
+}

--- a/frontend/src/models/memory.js
+++ b/frontend/src/models/memory.js
@@ -13,8 +13,19 @@ export class PercentageMemory {
     this.id = uniqueId("memory_percent_");
   }
 
+  clearMemory() {
+    this.playedCards = [];
+  }
+
   memorize(playedCard) {
     if (Math.random() <= this.percent) this.playedCards.push(playedCard);
+  }
+
+  fehlSuitPlayedBefore(suit) {
+    return (
+      this.playedCards.filter(playedCard => playedCard.card.suit === suit)
+        .length > 0
+    );
   }
 }
 
@@ -24,8 +35,19 @@ export class PerfectMemory {
     this.id = uniqueId("memory_perfect_");
   }
 
+  clearMemory() {
+    this.playedCards = [];
+  }
+
   memorize(playedCard) {
     this.playedCards.push(playedCard);
+  }
+
+  fehlSuitPlayedBefore(suit) {
+    return (
+      this.playedCards.filter(playedCard => playedCard.card.suit === suit)
+        .length > 0
+    );
   }
 }
 
@@ -33,6 +55,10 @@ export class PriorityMemory {
   constructor() {
     this.playedCards = [];
     this.id = uniqueId("memory_priority_");
+  }
+
+  clearMemory() {
+    this.playedCards = [];
   }
 
   memorize(playedCard) {
@@ -43,5 +69,12 @@ export class PriorityMemory {
     */
     if ([3, 10, 11].includes(playedCard.card.value))
       this.playedCards.push(playedCard);
+  }
+
+  fehlSuitPlayedBefore(suit) {
+    return (
+      this.playedCards.filter(playedCard => playedCard.card.suit === suit)
+        .length > 0
+    );
   }
 }

--- a/frontend/src/models/memory.js
+++ b/frontend/src/models/memory.js
@@ -21,7 +21,7 @@ export class PercentageMemory {
     if (Math.random() <= this.percent) this.playedCards.push(playedCard);
   }
 
-  fehlSuitPlayedBefore(suit) {
+  nonTrumpSuitPlayedBefore(suit) {
     return (
       this.playedCards.filter(playedCard => playedCard.card.suit === suit)
         .length > 0
@@ -52,7 +52,7 @@ export class PerfectMemory {
     this.playedCards.push(playedCard);
   }
 
-  fehlSuitPlayedBefore(suit) {
+  nonTrumpSuitPlayedBefore(suit) {
     return (
       this.playedCards.filter(playedCard => playedCard.card.suit === suit)
         .length > 0
@@ -89,7 +89,7 @@ export class PriorityMemory {
       this.playedCards.push(playedCard);
   }
 
-  fehlSuitPlayedBefore(suit) {
+  nonTrumpSuitPlayedBefore(suit) {
     return (
       this.playedCards.filter(playedCard => playedCard.card.suit === suit)
         .length > 0

--- a/frontend/src/models/memory.js
+++ b/frontend/src/models/memory.js
@@ -27,6 +27,15 @@ export class PercentageMemory {
         .length > 0
     );
   }
+
+  pointsLeftInSuit(suit) {
+    return (
+      50 -
+      this.playedCards
+        .filter(playedCard => playedCard.card.suit === suit)
+        .reduce((accu, playedCard) => accu + playedCard.card.value, 0)
+    );
+  }
 }
 
 export class PerfectMemory {
@@ -49,6 +58,15 @@ export class PerfectMemory {
         .length > 0
     );
   }
+
+  pointsLeftInSuit(suit) {
+    return (
+      50 -
+      this.playedCards
+        .filter(playedCard => playedCard.card.suit === suit)
+        .reduce((accu, playedCard) => accu + playedCard.card.value, 0)
+    );
+  }
 }
 
 export class PriorityMemory {
@@ -63,7 +81,7 @@ export class PriorityMemory {
 
   memorize(playedCard) {
     /*
-    Superb function to take care of 'important' cards
+    Opinion-biased function to take care of 'important' cards
     Will memorize all by value
     Queens, Tens, Aces
     */
@@ -75,6 +93,15 @@ export class PriorityMemory {
     return (
       this.playedCards.filter(playedCard => playedCard.card.suit === suit)
         .length > 0
+    );
+  }
+
+  pointsLeftInSuit(suit) {
+    return (
+      50 -
+      this.playedCards
+        .filter(playedCard => playedCard.card.suit === suit)
+        .reduce((accu, playedCard) => accu + playedCard.card.value, 0)
     );
   }
 }

--- a/frontend/src/models/playedCard.js
+++ b/frontend/src/models/playedCard.js
@@ -7,7 +7,3 @@ export class PlayedCard {
     this.id = `${this.card.id}-${this.player.id}`;
   }
 }
-
-export function beats(one, two) {
-  return one.card.compareTo(two.card);
-}

--- a/frontend/src/models/player.js
+++ b/frontend/src/models/player.js
@@ -49,7 +49,8 @@ export class Player {
   autoplay() {
     const cardToBePlayed = this.behavior.cardToPlay(
       this.hand,
-      this.game.currentTrick.baseCard()
+      this.game.currentTrick,
+      this.memory
     );
     this.play(cardToBePlayed);
 

--- a/frontend/src/models/player.js
+++ b/frontend/src/models/player.js
@@ -1,7 +1,7 @@
 import { includes, uniqueId } from "lodash-es";
 import { Hand } from "@/models/hand";
 import { TrickStack } from "@/models/trickStack";
-import { BasicRuleBasedBehaviour } from "@/models/behaviors";
+import { RuleBasedBehaviour } from "@/models/behaviors";
 import { Notifier } from "@/models/notifier";
 import { options } from "@/models/options";
 import { announcements } from "@/models/announcements";
@@ -18,7 +18,7 @@ export class Player {
     isMe = false,
     tablePosition = "bottom", // todo: remove 'position', introduce new 'table view' class?
     game = {},
-    behaviour = new BasicRuleBasedBehaviour(),
+    behaviour = new RuleBasedBehaviour(),
     memory = new PerfectMemory()
   ) {
     this.id = uniqueId("player_");

--- a/frontend/src/models/player.js
+++ b/frontend/src/models/player.js
@@ -17,7 +17,9 @@ export class Player {
     isHuman = false,
     isMe = false,
     tablePosition = "bottom", // todo: remove 'position', introduce new 'table view' class?
-    game = {}
+    game = {},
+    behaviour = new BasicRuleBasedBehaviour(),
+    memory = new PerfectMemory()
   ) {
     this.id = uniqueId("player_");
     this.name = name;
@@ -26,8 +28,8 @@ export class Player {
     this.isMe = isMe;
     this.tablePosition = tablePosition;
     this.game = game;
-    this.behavior = new BasicRuleBasedBehaviour();
-    this.memory = new PerfectMemory();
+    this.behavior = behaviour;
+    this.memory = memory;
 
     this.reset();
   }
@@ -38,12 +40,6 @@ export class Player {
 
   isKontra() {
     return !this.isRe();
-  }
-
-  callMemorizeFunctionForAllPlayers(card) {
-    this.game.players.forEach(player => {
-      player.memory.memorize(new PlayedCard(card, this));
-    });
   }
 
   autoplay() {
@@ -80,8 +76,9 @@ export class Player {
     try {
       this.game.currentTrick.add(cardToBePlayed, this);
       this.hand.remove(cardToBePlayed);
-      this.callMemorizeFunctionForAllPlayers(cardToBePlayed);
-      console.debug(cardToBePlayed.cardId);
+      console.debug(
+        "Player " + this.name + " played: " + cardToBePlayed.cardId
+      );
       this.game.currentRound.nextPlayer();
 
       if (options.autoplay === true) {

--- a/frontend/src/models/player.js
+++ b/frontend/src/models/player.js
@@ -1,7 +1,7 @@
 import { includes, uniqueId } from "lodash-es";
 import { Hand } from "@/models/hand";
 import { TrickStack } from "@/models/trickStack";
-import { RandomCardBehavior } from "@/models/behaviors";
+import { BasicRuleBasedBehaviour } from "@/models/behaviors";
 import { Notifier } from "@/models/notifier";
 import { options } from "@/models/options";
 import { announcements } from "@/models/announcements";
@@ -26,7 +26,7 @@ export class Player {
     this.isMe = isMe;
     this.tablePosition = tablePosition;
     this.game = game;
-    this.behavior = new RandomCardBehavior();
+    this.behavior = new BasicRuleBasedBehaviour();
     this.memory = new PerfectMemory();
 
     this.reset();

--- a/frontend/src/models/player.js
+++ b/frontend/src/models/player.js
@@ -6,6 +6,8 @@ import { Notifier } from "@/models/notifier";
 import { options } from "@/models/options";
 import { announcements } from "@/models/announcements";
 import { playableCards } from "@/models/playableCardFinder";
+import { PerfectMemory } from "./memory";
+import { PlayedCard } from "./playedCard";
 
 const notifier = new Notifier();
 
@@ -25,6 +27,7 @@ export class Player {
     this.tablePosition = tablePosition;
     this.game = game;
     this.behavior = new RandomCardBehavior();
+    this.memory = new PerfectMemory();
 
     this.reset();
   }
@@ -35,6 +38,12 @@ export class Player {
 
   isKontra() {
     return !this.isRe();
+  }
+
+  callMemorizeFunctionForAllPlayers(card) {
+    this.game.players.forEach(player => {
+      player.memory.memorize(new PlayedCard(card, this));
+    });
   }
 
   autoplay() {
@@ -70,6 +79,8 @@ export class Player {
     try {
       this.game.currentTrick.add(cardToBePlayed, this);
       this.hand.remove(cardToBePlayed);
+      this.callMemorizeFunctionForAllPlayers(cardToBePlayed);
+      console.debug(cardToBePlayed.cardId);
       this.game.currentRound.nextPlayer();
 
       if (options.autoplay === true) {

--- a/frontend/src/models/trick.js
+++ b/frontend/src/models/trick.js
@@ -62,13 +62,13 @@ export class Trick {
       return undefined;
     }
 
-    let highestCard = this.playedCards[0];
-    for (let card of this.playedCards) {
-      if (beats(card, highestCard) < 0) {
-        highestCard = card;
+    let highestPlayed = this.playedCards[0];
+    for (let played of this.playedCards) {
+      if (played.card.beats(highestPlayed.card)) {
+        highestPlayed = played;
       }
     }
-    return highestCard;
+    return highestPlayed;
   }
 
   winner() {

--- a/frontend/src/models/trick.js
+++ b/frontend/src/models/trick.js
@@ -29,6 +29,10 @@ export class Trick {
     if (this.playedCards.length === this.expectedNumberOfCards) {
       this.finished = true;
     }
+
+    this.players.forEach(playerLoop => {
+      playerLoop.memory.memorize(new PlayedCard(card, player));
+    });
   }
 
   cards() {

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -90,8 +90,8 @@ const hand = new Hand([
 ]);
 
 describe("Basic Rule Based Card Behavior", () => {
-  describe("Fehl has been played for the first time", () => {
-    test("should play lowest value fehl when not starting", () => {
+  describe("Non-trump has been played for the first time", () => {
+    test("should play lowest value nonTrump when not starting", () => {
       const trick = new Trick([player1, player2, player3, player4]);
       trick.add(ace.of(suits.clubs).second(), player1);
       trick.add(ten.of(suits.clubs).second(), player2);
@@ -181,7 +181,7 @@ describe("Basic Rule Based Card Behavior", () => {
     });
   });
 
-  describe("Fehl has been played already", () => {
+  describe("Non-trump has been played already", () => {
     beforeEach(() => {
       player1.memory.clearMemory();
       player2.memory.clearMemory();

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -9,6 +9,7 @@ import { ace, king, queen, jack, suits, ten, Card } from "@/models/card";
 import { Trick } from "@/models/trick";
 import { Player } from "@/models/player";
 import { PerfectMemory } from "@/models/memory";
+import { PlayedCard } from "@/models/playedCard";
 
 jest.mock("@/models/random", () => ({
   __esModule: true,
@@ -89,81 +90,111 @@ const hand = new Hand([
 ]);
 
 describe("Basic Rule Based Card Behavior", () => {
-  test("should play lowest value fehl when not starting", () => {
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ace.of(suits.clubs).second(), player1);
-    trick.add(ten.of(suits.clubs).second(), player2);
-    trick.add(king.of(suits.clubs).second(), player3);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(king.of(suits.clubs).first());
+  describe("Fehl has been played for the first time", () => {
+    test("should play lowest value fehl when not starting", () => {
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ace.of(suits.clubs).second(), player1);
+      trick.add(ten.of(suits.clubs).second(), player2);
+      trick.add(king.of(suits.clubs).second(), player3);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(king.of(suits.clubs).first());
+    });
+
+    test("should play ace of suit, when first time served and lower card was played", () => {
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ten.of(suits.clubs).second(), player1);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(ace.of(suits.clubs).first());
+    });
+
+    test("should play lowest of suit, when first time served and not able to go higher", () => {
+      let hand = new Hand([king.of(suits.clubs).first(), ten.of(suits.clubs)]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ten.of(suits.clubs).second(), player1);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(king.of(suits.clubs).first());
+    });
+
+    test("should play ace, when mustn't serve", () => {
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ace.of(suits.hearts).second(), player1);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(ace.of(suits.diamonds).first());
+    });
+
+    test("should play higher trump when mustn't serve and somebody else is trumping", () => {
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ace.of(suits.hearts).second(), player1);
+      trick.add(ten.of(suits.diamonds).second(), player2);
+      trick.add(ace.of(suits.diamonds).second(), player3);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(jack.of(suits.diamonds).first());
+    });
+
+    test("should play jack, when mustn't serve and high value card isn't available", () => {
+      let hand = new Hand([
+        king.of(suits.diamonds),
+        jack.of(suits.diamonds).first(),
+        ten.of(suits.hearts)
+      ]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ace.of(suits.hearts).second(), player1);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(jack.of(suits.diamonds).first());
+    });
+
+    test("should play lowest card, when can't win because too many cards of suit in own hand", () => {
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(king.of(suits.spades).second(), player1);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(king.of(suits.spades).first());
+    });
+
+    test("should keep playing a card, if can't serve or trump a suit", () => {
+      let hand = new Hand([king.of(suits.spades), ten.of(suits.spades)]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ace.of(suits.hearts).second(), player1);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(expect.any(Card));
+    });
+
+    test("should keep playing a card, if can't win a trumped suit", () => {
+      let hand = new Hand([jack.of(suits.spades), ten.of(suits.spades)]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      trick.add(ace.of(suits.hearts).second(), player1);
+      trick.add(jack.of(suits.spades).second(), player2);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(expect.any(Card));
+    });
   });
 
-  test("should play ace of suit, when first time served and lower card was played", () => {
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ten.of(suits.clubs).second(), player1);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(ace.of(suits.clubs).first());
-  });
+  describe("Fehl has been played already", () => {
+    test("should keep playing a card, if can't play same suit", () => {
+      let hand = new Hand([jack.of(suits.spades), ten.of(suits.diamonds)]);
+      let memory = new PerfectMemory();
+      const trick = new Trick([player1, player2, player3, player4]);
+      const aceOfClubs = ace.of(suits.clubs).second();
+      const jackOfDiamonds = jack.of(suits.diamonds).second();
+      trick.add(aceOfClubs, player1);
+      memory.memorize(aceOfClubs, player1);
+      trick.add(jackOfDiamonds, player2);
+      memory.memorize(jackOfDiamonds, player2);
+      const cardToPlay = behavior.cardToPlay(hand, trick, memory);
+      expect(cardToPlay).toEqual(expect.any(Card));
+    });
 
-  test("should play lowest of suit, when first time served and not able to go higher", () => {
-    let hand = new Hand([king.of(suits.clubs).first(), ten.of(suits.clubs)]);
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ten.of(suits.clubs).second(), player1);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(king.of(suits.clubs).first());
+    test("should play low card, if must serve suit", () => {
+      let hand = new Hand([ace.of(suits.clubs), king.of(suits.clubs).first()]);
+      let memory = new PerfectMemory();
+      const trick = new Trick([player1, player2, player3, player4]);
+      const aceOfClubs = ace.of(suits.clubs).second();
+      const jackOfDiamonds = jack.of(suits.diamonds).second();
+      trick.add(aceOfClubs, player1);
+      memory.memorize(new PlayedCard(aceOfClubs, player1));
+      trick.add(jackOfDiamonds, player2);
+      memory.memorize(new PlayedCard(jackOfDiamonds, player2));
+      const cardToPlay = behavior.cardToPlay(hand, trick, memory);
+      expect(cardToPlay).toEqual(king.of(suits.clubs).first());
+    });
   });
-
-  test("should play ace, when mustn't serve", () => {
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ace.of(suits.hearts).second(), player1);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(ace.of(suits.diamonds).first());
-  });
-
-  test("should play higher trump when mustn't serve and somebody else is trumping", () => {
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ace.of(suits.hearts).second(), player1);
-    trick.add(ten.of(suits.diamonds).second(), player2);
-    trick.add(ace.of(suits.diamonds).second(), player3);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(jack.of(suits.diamonds).first());
-  });
-
-  test("should play jack, when mustn't serve and high value card isn't available", () => {
-    let hand = new Hand([
-      king.of(suits.diamonds),
-      jack.of(suits.diamonds).first(),
-      ten.of(suits.hearts)
-    ]);
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ace.of(suits.hearts).second(), player1);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(jack.of(suits.diamonds).first());
-  });
-
-  test("should play lowest card, when can't win because too many cards of suit in own hand", () => {
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(king.of(suits.spades).second(), player1);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(king.of(suits.spades).first());
-  });
-
-  test("should keep playing a card, if can't serve or trump a suit", () => {
-    let hand = new Hand([king.of(suits.spades), ten.of(suits.spades)]);
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ace.of(suits.hearts).second(), player1);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(expect.any(Card));
-  });
-
-  test("should keep playing a card, if can't win a trumped suit", () => {
-    let hand = new Hand([jack.of(suits.spades), ten.of(suits.spades)]);
-    const trick = new Trick([player1, player2, player3, player4]);
-    trick.add(ace.of(suits.hearts).second(), player1);
-    trick.add(jack.of(suits.spades).second(), player2);
-    const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
-    expect(cardToPlay).toEqual(expect.any(Card));
-  });
-
-  // ToDo how about it's the suit has been already played (multiple times)?
 });

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -89,7 +89,7 @@ const hand = new Hand([
   king.of(suits.spades).first()
 ]);
 
-describe("Basic Rule Based Card Behavior", () => {
+describe("Rule Based Card Behavior", () => {
   describe("Non-trump has been played for the first time", () => {
     test("should play lowest value nonTrump when not starting", () => {
       const trick = new Trick([player1, player2, player3, player4]);

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -169,31 +169,31 @@ describe("Basic Rule Based Card Behavior", () => {
   });
 
   describe("Fehl has been played already", () => {
+    beforeEach(() => {
+      player1.memory.clearMemory();
+      player2.memory.clearMemory();
+      player3.memory.clearMemory();
+      player4.memory.clearMemory();
+    });
     test("should keep playing a card, if can't play same suit", () => {
       let hand = new Hand([jack.of(suits.spades), ten.of(suits.diamonds)]);
-      let memory = new PerfectMemory();
       const trick = new Trick([player1, player2, player3, player4]);
       const aceOfClubs = ace.of(suits.clubs).second();
       const jackOfDiamonds = jack.of(suits.diamonds).second();
       trick.add(aceOfClubs, player1);
-      memory.memorize(aceOfClubs, player1);
       trick.add(jackOfDiamonds, player2);
-      memory.memorize(jackOfDiamonds, player2);
-      const cardToPlay = behavior.cardToPlay(hand, trick, memory);
+      const cardToPlay = behavior.cardToPlay(hand, trick, player1.memory);
       expect(cardToPlay).toEqual(expect.any(Card));
     });
 
     test("should play low card, if must serve suit", () => {
       let hand = new Hand([ace.of(suits.clubs), king.of(suits.clubs).first()]);
-      let memory = new PerfectMemory();
       const trick = new Trick([player1, player2, player3, player4]);
       const aceOfClubs = ace.of(suits.clubs).second();
       const jackOfDiamonds = jack.of(suits.diamonds).second();
       trick.add(aceOfClubs, player1);
-      memory.memorize(new PlayedCard(aceOfClubs, player1));
       trick.add(jackOfDiamonds, player2);
-      memory.memorize(new PlayedCard(jackOfDiamonds, player2));
-      const cardToPlay = behavior.cardToPlay(hand, trick, memory);
+      const cardToPlay = behavior.cardToPlay(hand, trick, player1.memory);
       expect(cardToPlay).toEqual(king.of(suits.clubs).first());
     });
   });

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -1,5 +1,5 @@
 import {
-  BasicRuleBasedBehaviour,
+  RuleBasedBehaviour,
   HighestCardBehavior,
   RandomCardBehavior
 } from "@/models/behaviors";
@@ -69,7 +69,7 @@ describe("Random Card Behavior", () => {
   });
 });
 
-const behavior = new BasicRuleBasedBehaviour();
+const behavior = new RuleBasedBehaviour();
 const no_memory = new PerfectMemory();
 const player1 = new Player();
 const player2 = new Player();

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -2,6 +2,8 @@ import { HighestCardBehavior, RandomCardBehavior } from "@/models/behaviors";
 import { Hand } from "@/models/hand";
 import { announcements } from "@/models/announcements";
 import { ace, king, queen, jack, suits, ten, Card } from "@/models/card";
+import { Trick } from "@/models/trick";
+import { Player } from "@/models/player";
 
 jest.mock("@/models/random", () => ({
   __esModule: true,
@@ -16,9 +18,12 @@ describe("Highest Card Behavior", () => {
     queen.of(suits.spades).second(),
     king.of(suits.hearts).first()
   ]);
+  const player = new Player(new Player());
+  const trick = new Trick([player]);
+  trick.add(ten.of(suits.diamonds), player);
 
   test("should play highest possible card", () => {
-    const cardToPlay = behavior.cardToPlay(hand, ten.of(suits.diamonds));
+    const cardToPlay = behavior.cardToPlay(hand, trick);
     expect(cardToPlay).toEqual(queen.of(suits.spades).second());
   });
 });
@@ -31,9 +36,12 @@ describe("Random Card Behavior", () => {
     queen.of(suits.spades).second(),
     king.of(suits.hearts).first()
   ]);
+  const player = new Player(new Player());
+  const trick = new Trick([player]);
+  trick.add(ten.of(suits.diamonds), player);
 
   test("should play a random card", () => {
-    const cardToPlay = behavior.cardToPlay(hand, ten.of(suits.diamonds));
+    const cardToPlay = behavior.cardToPlay(hand, trick);
     expect(cardToPlay).toEqual(expect.any(Card));
   });
 

--- a/frontend/tests/unit/models/behaviours.test.js
+++ b/frontend/tests/unit/models/behaviours.test.js
@@ -166,6 +166,19 @@ describe("Basic Rule Based Card Behavior", () => {
       const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
       expect(cardToPlay).toEqual(expect.any(Card));
     });
+
+    test("should start with ace", () => {
+      let hand = new Hand([
+        ace.of(suits.spades).first(),
+        ace.of(suits.clubs),
+        ten.of(suits.clubs),
+        ace.of(suits.hearts),
+        ace.of(suits.diamonds)
+      ]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      const cardToPlay = behavior.cardToPlay(hand, trick, no_memory);
+      expect(cardToPlay).toEqual(ace.of(suits.spades).first());
+    });
   });
 
   describe("Fehl has been played already", () => {
@@ -175,6 +188,7 @@ describe("Basic Rule Based Card Behavior", () => {
       player3.memory.clearMemory();
       player4.memory.clearMemory();
     });
+
     test("should keep playing a card, if can't play same suit", () => {
       let hand = new Hand([jack.of(suits.spades), ten.of(suits.diamonds)]);
       const trick = new Trick([player1, player2, player3, player4]);
@@ -195,6 +209,35 @@ describe("Basic Rule Based Card Behavior", () => {
       trick.add(jackOfDiamonds, player2);
       const cardToPlay = behavior.cardToPlay(hand, trick, player1.memory);
       expect(cardToPlay).toEqual(king.of(suits.clubs).first());
+    });
+
+    test("should start with ace, ignoring already played suit", () => {
+      let hand = new Hand([
+        ace.of(suits.spades),
+        ace.of(suits.clubs),
+        ten.of(suits.clubs),
+        ace.of(suits.hearts).first(),
+        ace.of(suits.diamonds)
+      ]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      player1.memory.memorize(new PlayedCard(ten.of(suits.spades), player2));
+      const cardToPlay = behavior.cardToPlay(hand, trick, player1.memory);
+      expect(cardToPlay).toEqual(ace.of(suits.hearts).first());
+    });
+
+    test("should play card, ignoring aces with played suit", () => {
+      let hand = new Hand([
+        ten.of(suits.clubs),
+        ace.of(suits.hearts),
+        ace.of(suits.diamonds),
+        jack.of(suits.diamonds),
+        queen.of(suits.diamonds),
+        king.of(suits.spades)
+      ]);
+      const trick = new Trick([player1, player2, player3, player4]);
+      player1.memory.memorize(new PlayedCard(king.of(suits.hearts), player2));
+      const cardToPlay = behavior.cardToPlay(hand, trick, player1.memory);
+      expect(cardToPlay).toEqual(expect.any(Card));
     });
   });
 });

--- a/frontend/tests/unit/models/hand.test.js
+++ b/frontend/tests/unit/models/hand.test.js
@@ -213,3 +213,64 @@ test("should detect hand with trumps equal or lesser than jack of diamonds", () 
 
   expect(hand.isPlayable()).toBe(false);
 });
+
+test("should detect suits that can be served", () => {
+  const cards = [
+    king.of(suits.hearts),
+    king.of(suits.hearts),
+    ten.of(suits.clubs),
+    ten.of(suits.clubs),
+    ten.of(suits.hearts),
+    ten.of(suits.hearts),
+    ten.of(suits.diamonds),
+    ten.of(suits.diamonds),
+    jack.of(suits.spades),
+    jack.of(suits.spades)
+  ];
+  const hand = new Hand(cards);
+
+  expect(hand.fehlCardsBySuit(suits.spades).length).toEqual(0);
+  expect(hand.fehlCardsBySuit(suits.hearts).length).toEqual(2);
+  expect(hand.fehlCardsBySuit(suits.clubs).length).toEqual(2);
+  expect(hand.mustServeSuit(suits.spades)).toBe(false);
+  expect(hand.mustServeSuit(suits.hearts)).toBe(true);
+  expect(hand.mustServeSuit(suits.clubs)).toBe(true);
+});
+
+test("should detect correct number of trumps in hand", () => {
+  const cards = [
+    king.of(suits.hearts),
+    king.of(suits.hearts),
+    ten.of(suits.clubs),
+    ten.of(suits.clubs),
+    ten.of(suits.spades),
+    ten.of(suits.spades),
+    ten.of(suits.diamonds),
+    ten.of(suits.diamonds),
+    jack.of(suits.diamonds),
+    jack.of(suits.diamonds)
+  ];
+  const hand = new Hand(cards);
+
+  expect(hand.trumps().length).toEqual(4);
+});
+
+test("should detect multiple single blank aces", () => {
+  const cards = [
+    ace.of(suits.hearts),
+    ace.of(suits.spades),
+    king.of(suits.clubs),
+    ten.of(suits.clubs),
+    ace.of(suits.clubs),
+    ten.of(suits.hearts),
+    ten.of(suits.hearts),
+    queen.of(suits.diamonds),
+    queen.of(suits.diamonds),
+    jack.of(suits.spades)
+  ];
+  const hand = new Hand(cards);
+
+  expect(hand.hasBlankAce(suits.clubs)).toBe(false);
+  expect(hand.hasBlankAce(suits.hearts)).toBe(true);
+  expect(hand.hasBlankAce(suits.spades)).toBe(true);
+});

--- a/frontend/tests/unit/models/hand.test.js
+++ b/frontend/tests/unit/models/hand.test.js
@@ -229,9 +229,9 @@ test("should detect suits that can be served", () => {
   ];
   const hand = new Hand(cards);
 
-  expect(hand.fehlCardsBySuit(suits.spades).length).toEqual(0);
-  expect(hand.fehlCardsBySuit(suits.hearts).length).toEqual(2);
-  expect(hand.fehlCardsBySuit(suits.clubs).length).toEqual(2);
+  expect(hand.nonTrumpCardsBySuit(suits.spades).length).toEqual(0);
+  expect(hand.nonTrumpCardsBySuit(suits.hearts).length).toEqual(2);
+  expect(hand.nonTrumpCardsBySuit(suits.clubs).length).toEqual(2);
   expect(hand.mustServeSuit(suits.spades)).toBe(false);
   expect(hand.mustServeSuit(suits.hearts)).toBe(true);
   expect(hand.mustServeSuit(suits.clubs)).toBe(true);

--- a/frontend/tests/unit/models/hand.test.js
+++ b/frontend/tests/unit/models/hand.test.js
@@ -47,12 +47,28 @@ test("empty hand has a value of 0", () => {
   expect(hand.value()).toBe(0);
 });
 
-test("can find card on hand", () => {
+test("can find specific card on hand", () => {
   const queenOfSpades = queen.of(suits.spades);
   const cards = [queenOfSpades];
   const hand = new Hand(cards);
 
   expect(hand.find(cards[0])).toEqual(queenOfSpades);
+});
+
+test("can find card on hand by rank and suit", () => {
+  const queenOfSpades = queen.of(suits.spades);
+  const cards = [queenOfSpades];
+  const hand = new Hand(cards);
+
+  expect(hand.findAny(suits.spades, ranks.queen)).toEqual(queenOfSpades);
+});
+
+test("should return empty list if card on hand cannot be found by rank and suit", () => {
+  const queenOfSpades = queen.of(suits.spades);
+  const cards = [queenOfSpades];
+  const hand = new Hand(cards);
+
+  expect(hand.findAny(suits.spades, ranks.king)).toBeUndefined;
 });
 
 test("can not find non-existing card on hand", () => {

--- a/frontend/tests/unit/models/hand.test.js
+++ b/frontend/tests/unit/models/hand.test.js
@@ -229,12 +229,12 @@ test("should detect suits that can be served", () => {
   ];
   const hand = new Hand(cards);
 
-  expect(hand.nonTrumpCardsBySuit(suits.spades).length).toEqual(0);
-  expect(hand.nonTrumpCardsBySuit(suits.hearts).length).toEqual(2);
-  expect(hand.nonTrumpCardsBySuit(suits.clubs).length).toEqual(2);
-  expect(hand.mustServeSuit(suits.spades)).toBe(false);
-  expect(hand.mustServeSuit(suits.hearts)).toBe(true);
-  expect(hand.mustServeSuit(suits.clubs)).toBe(true);
+  expect(hand.nonTrumps(suits.spades).length).toEqual(0);
+  expect(hand.nonTrumps(suits.hearts).length).toEqual(2);
+  expect(hand.nonTrumps(suits.clubs).length).toEqual(2);
+  expect(hand.hasNonTrumps(suits.spades)).toBe(false);
+  expect(hand.hasNonTrumps(suits.hearts)).toBe(true);
+  expect(hand.hasNonTrumps(suits.clubs)).toBe(true);
 });
 
 test("should detect correct number of trumps in hand", () => {

--- a/frontend/tests/unit/models/hand.test.js
+++ b/frontend/tests/unit/models/hand.test.js
@@ -257,15 +257,15 @@ test("should detect correct number of trumps in hand", () => {
 
 test("should detect multiple single blank aces", () => {
   const cards = [
-    ace.of(suits.hearts),
-    ace.of(suits.spades),
+    ace.of(suits.hearts).first(),
+    ace.of(suits.spades).first(),
     king.of(suits.clubs),
     ten.of(suits.clubs),
     ace.of(suits.clubs),
     ten.of(suits.hearts),
     ten.of(suits.hearts),
     queen.of(suits.diamonds),
-    queen.of(suits.diamonds),
+    ace.of(suits.diamonds),
     jack.of(suits.spades)
   ];
   const hand = new Hand(cards);
@@ -273,4 +273,8 @@ test("should detect multiple single blank aces", () => {
   expect(hand.hasBlankAce(suits.clubs)).toBe(false);
   expect(hand.hasBlankAce(suits.hearts)).toBe(true);
   expect(hand.hasBlankAce(suits.spades)).toBe(true);
+  expect(hand.getBlankAces()).toEqual([
+    ace.of(suits.spades).first(),
+    ace.of(suits.hearts).first()
+  ]);
 });

--- a/frontend/tests/unit/models/memory.test.js
+++ b/frontend/tests/unit/models/memory.test.js
@@ -72,4 +72,13 @@ describe("Testing functionality", () => {
     memory.clearMemory();
     expect(memory.playedCards.length).toBe(0);
   });
+
+  test("Should calculate points left in suit", () => {
+    const memory = new PerfectMemory();
+    memory.memorize(new PlayedCard(ace.of(suits.spades), new Player()));
+    memory.memorize(new PlayedCard(ten.of(suits.spades), new Player()));
+    memory.memorize(new PlayedCard(king.of(suits.spades), new Player()));
+    memory.memorize(new PlayedCard(king.of(suits.spades), new Player()));
+    expect(memory.pointsLeftInSuit(suits.spades)).toBe(21);
+  });
 });

--- a/frontend/tests/unit/models/memory.test.js
+++ b/frontend/tests/unit/models/memory.test.js
@@ -1,0 +1,46 @@
+import { ace, jack, king, queen, suits, ten } from "@/models/card";
+import { PlayedCard } from "@/models/playedCard";
+import { Player } from "@/models/player";
+import {
+  PercentageMemory,
+  PerfectMemory,
+  PriorityMemory
+} from "@/models/memory";
+
+test("perfect memory memorizes everything", () => {
+  const memory = new PerfectMemory();
+  const player = new Player();
+  memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+  memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+  memory.memorize(new PlayedCard(jack.of(suits.hearts), player));
+  memory.memorize(new PlayedCard(jack.of(suits.hearts), player));
+  memory.memorize(new PlayedCard(jack.of(suits.spades), player));
+  memory.memorize(new PlayedCard(jack.of(suits.spades), player));
+  memory.memorize(new PlayedCard(jack.of(suits.clubs), player));
+  memory.memorize(new PlayedCard(jack.of(suits.clubs), player));
+  expect(memory.playedCards.length).toBe(8);
+});
+
+test("percentage memory memorizes a percentage of things", () => {
+  const memory = new PercentageMemory(0.9);
+  const player = new Player();
+  for (let index = 0; index < 10000; index++) {
+    memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+  }
+  expect(memory.playedCards.length).toBeGreaterThanOrEqual(8700);
+  expect(memory.playedCards.length).toBeLessThanOrEqual(9300);
+});
+
+test("priority memory memorizes only specific cards", () => {
+  const memory = new PriorityMemory();
+  const player = new Player();
+  memory.memorize(new PlayedCard(king.of(suits.diamonds), player));
+  memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+  memory.memorize(new PlayedCard(ten.of(suits.hearts), player));
+  memory.memorize(new PlayedCard(queen.of(suits.spades), player));
+  memory.memorize(new PlayedCard(ten.of(suits.hearts), player));
+  memory.memorize(new PlayedCard(king.of(suits.spades), player));
+  memory.memorize(new PlayedCard(ace.of(suits.diamonds), player));
+  memory.memorize(new PlayedCard(ace.of(suits.clubs), player));
+  expect(memory.playedCards.length).toBe(5);
+});

--- a/frontend/tests/unit/models/memory.test.js
+++ b/frontend/tests/unit/models/memory.test.js
@@ -7,40 +7,69 @@ import {
   PriorityMemory
 } from "@/models/memory";
 
-test("perfect memory memorizes everything", () => {
-  const memory = new PerfectMemory();
-  const player = new Player();
-  memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
-  memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
-  memory.memorize(new PlayedCard(jack.of(suits.hearts), player));
-  memory.memorize(new PlayedCard(jack.of(suits.hearts), player));
-  memory.memorize(new PlayedCard(jack.of(suits.spades), player));
-  memory.memorize(new PlayedCard(jack.of(suits.spades), player));
-  memory.memorize(new PlayedCard(jack.of(suits.clubs), player));
-  memory.memorize(new PlayedCard(jack.of(suits.clubs), player));
-  expect(memory.playedCards.length).toBe(8);
-});
-
-test("percentage memory memorizes a percentage of things", () => {
-  const memory = new PercentageMemory(0.9);
-  const player = new Player();
-  for (let index = 0; index < 10000; index++) {
+describe("Testing memorize function", () => {
+  test("perfect memory memorizes everything", () => {
+    const memory = new PerfectMemory();
+    const player = new Player();
     memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
-  }
-  expect(memory.playedCards.length).toBeGreaterThanOrEqual(8700);
-  expect(memory.playedCards.length).toBeLessThanOrEqual(9300);
+    memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+    memory.memorize(new PlayedCard(jack.of(suits.hearts), player));
+    memory.memorize(new PlayedCard(jack.of(suits.hearts), player));
+    memory.memorize(new PlayedCard(jack.of(suits.spades), player));
+    memory.memorize(new PlayedCard(jack.of(suits.spades), player));
+    memory.memorize(new PlayedCard(jack.of(suits.clubs), player));
+    memory.memorize(new PlayedCard(jack.of(suits.clubs), player));
+    expect(memory.playedCards.length).toBe(8);
+  });
+
+  test("percentage memory memorizes a percentage of things", () => {
+    const memory = new PercentageMemory(0.9);
+    const player = new Player();
+    for (let index = 0; index < 10000; index++) {
+      memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+    }
+    expect(memory.playedCards.length).toBeGreaterThanOrEqual(8700);
+    expect(memory.playedCards.length).toBeLessThanOrEqual(9300);
+  });
+
+  test("priority memory memorizes only specific cards", () => {
+    const memory = new PriorityMemory();
+    const player = new Player();
+    memory.memorize(new PlayedCard(king.of(suits.diamonds), player));
+    memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
+    memory.memorize(new PlayedCard(ten.of(suits.hearts), player));
+    memory.memorize(new PlayedCard(queen.of(suits.spades), player));
+    memory.memorize(new PlayedCard(ten.of(suits.hearts), player));
+    memory.memorize(new PlayedCard(king.of(suits.spades), player));
+    memory.memorize(new PlayedCard(ace.of(suits.diamonds), player));
+    memory.memorize(new PlayedCard(ace.of(suits.clubs), player));
+    expect(memory.playedCards.length).toBe(5);
+  });
 });
 
-test("priority memory memorizes only specific cards", () => {
-  const memory = new PriorityMemory();
-  const player = new Player();
-  memory.memorize(new PlayedCard(king.of(suits.diamonds), player));
-  memory.memorize(new PlayedCard(jack.of(suits.diamonds), player));
-  memory.memorize(new PlayedCard(ten.of(suits.hearts), player));
-  memory.memorize(new PlayedCard(queen.of(suits.spades), player));
-  memory.memorize(new PlayedCard(ten.of(suits.hearts), player));
-  memory.memorize(new PlayedCard(king.of(suits.spades), player));
-  memory.memorize(new PlayedCard(ace.of(suits.diamonds), player));
-  memory.memorize(new PlayedCard(ace.of(suits.clubs), player));
-  expect(memory.playedCards.length).toBe(5);
+describe("Testing functionality", () => {
+  test("Should detect that suit hasn't been played", () => {
+    const memory = new PerfectMemory();
+    expect(memory.fehlSuitPlayedBefore(suits.hearts)).toEqual(false);
+    expect(memory.fehlSuitPlayedBefore(suits.spades)).toEqual(false);
+    expect(memory.fehlSuitPlayedBefore(suits.clubs)).toEqual(false);
+  });
+
+  test("Should detect that suit has been played", () => {
+    const memory = new PerfectMemory();
+    memory.memorize(new PlayedCard(ace.of(suits.hearts), new Player()));
+    memory.memorize(new PlayedCard(ace.of(suits.spades), new Player()));
+    expect(memory.fehlSuitPlayedBefore(suits.hearts)).toEqual(true);
+    expect(memory.fehlSuitPlayedBefore(suits.spades)).toEqual(true);
+    expect(memory.fehlSuitPlayedBefore(suits.clubs)).toEqual(false);
+  });
+
+  test("Should clear all playedCards from memory", () => {
+    const memory = new PerfectMemory();
+    memory.memorize(new PlayedCard(ace.of(suits.hearts), new Player()));
+    memory.memorize(new PlayedCard(ace.of(suits.spades), new Player()));
+    expect(memory.playedCards.length).toBe(2);
+    memory.clearMemory();
+    expect(memory.playedCards.length).toBe(0);
+  });
 });

--- a/frontend/tests/unit/models/memory.test.js
+++ b/frontend/tests/unit/models/memory.test.js
@@ -50,18 +50,18 @@ describe("Testing memorize function", () => {
 describe("Testing functionality", () => {
   test("Should detect that suit hasn't been played", () => {
     const memory = new PerfectMemory();
-    expect(memory.fehlSuitPlayedBefore(suits.hearts)).toEqual(false);
-    expect(memory.fehlSuitPlayedBefore(suits.spades)).toEqual(false);
-    expect(memory.fehlSuitPlayedBefore(suits.clubs)).toEqual(false);
+    expect(memory.nonTrumpSuitPlayedBefore(suits.hearts)).toEqual(false);
+    expect(memory.nonTrumpSuitPlayedBefore(suits.spades)).toEqual(false);
+    expect(memory.nonTrumpSuitPlayedBefore(suits.clubs)).toEqual(false);
   });
 
   test("Should detect that suit has been played", () => {
     const memory = new PerfectMemory();
     memory.memorize(new PlayedCard(ace.of(suits.hearts), new Player()));
     memory.memorize(new PlayedCard(ace.of(suits.spades), new Player()));
-    expect(memory.fehlSuitPlayedBefore(suits.hearts)).toEqual(true);
-    expect(memory.fehlSuitPlayedBefore(suits.spades)).toEqual(true);
-    expect(memory.fehlSuitPlayedBefore(suits.clubs)).toEqual(false);
+    expect(memory.nonTrumpSuitPlayedBefore(suits.hearts)).toEqual(true);
+    expect(memory.nonTrumpSuitPlayedBefore(suits.spades)).toEqual(true);
+    expect(memory.nonTrumpSuitPlayedBefore(suits.clubs)).toEqual(false);
   });
 
   test("Should clear all playedCards from memory", () => {

--- a/frontend/tests/unit/models/player.test.js
+++ b/frontend/tests/unit/models/player.test.js
@@ -158,7 +158,8 @@ test("should autoplay a card", () => {
   expect(player.hand.cards).not.toContain(kingOnHand);
   expect(player.behavior.cardToPlay).toBeCalledWith(
     player.hand,
-    expect.any(Card)
+    player.game.currentTrick,
+    player.memory
   );
 });
 


### PR DESCRIPTION
I implemented different kinds of memory objects for players, which will be used for a Rule based AI.
Based on them, it is possible to create an AI that knows about cards already played. Additionally I changed the cardToPlay() function to instead use the trick, since the trick other necessary information when deciding what to play.

Right now only a fehlRule is implemented, but this covers roughly 30-40% of the game, considering players will try to win fehl Tricks early in the game.

I suggest merging this asap, since it already improves the user experience enormously.
Obviously I will expand this branch and add more functionality in the future.

This is a list of things that come to my mind and I would like to add in the future:

- Implement affinities #32 as basis for decisionmaking
- Trumping enemies <> "Greasing" Teammate (whats the word for "schmieren")
- Starting a trick appropriately
- Meaningful announcements based on mathematical expectation or "goodies"
- Create a playerFabric style of object to create different kinds of player personalites using different memories and functions (basic and more complex) using dependency injection heavily.

There a few other fixes or improvements (already included).