### PR TITLE
fix charlie bug

### DIFF
--- a/frontend/src/models/game.ts
+++ b/frontend/src/models/game.ts
@@ -21,13 +21,13 @@ export class Game {
     this.players.map(p => (p.game = this));
     this.playerOpeningOrder = new RingQueue(this.players);
     this.deck = new Deck();
+    this.deal();
     this.scorecard = new Scorecard(this.players);
     this.currentRound = new Round(
       this.players,
       this.scorecard,
       this.playerOpeningOrder.current()
     );
-    this.deal();
     this.initializeAffinities();
     Telemetry.newGame();
   }


### PR DESCRIPTION
Round constructor initializes trick with nextTrick() function.
nextTrick() calculates lastTrickInRound through number of cards in hand.
Round is initialized before cards are dealt, therefore first trick
is wrongly calculated as last trick. Dealing cards before initializing
rounds solves this issue.

Unit Tests pass, playing the game doesn't create any sort of issues.
Solves issue #45 👍🏻

Please check for other issues that may arise :)