### PR TITLE
Fix announcement bug

### DIFF
--- a/frontend/src/models/player.ts
+++ b/frontend/src/models/player.ts
@@ -15,7 +15,7 @@ import { TablePosition } from "./tablePosition";
 import { Affinities, AffinityEvent } from "@/models/affinities";
 import { generateNames } from "@/models/random";
 import { allCards } from "./deck";
-import { findParties, PartyName } from "./party";
+import { findParties, Party, PartyName } from "./party";
 
 const notifier = new Notifier();
 
@@ -58,7 +58,6 @@ export class Player {
 
   static me(name?: string): Player {
     let playerName = name || generateNames(1)[0];
-    // todo: set multiplayer behavior here
     return new Player(playerName, true, true, TablePosition.Bottom);
   }
 
@@ -70,8 +69,9 @@ export class Player {
     return !this.isRe();
   }
 
-  getParty(): PartyName {
-    return this.isRe() ? PartyName.Re : PartyName.Kontra;
+  getParty(): Party {
+    const partyName = this.isRe() ? PartyName.Re : PartyName.Kontra;
+    return findParties(this.game!.players)[partyName];
   }
 
   autoplay() {
@@ -184,9 +184,7 @@ export class Player {
   }
 
   private getPartyAnnouncements(): Set<Announcement> {
-    return new Set<Announcement>(
-      findParties(this.game!.players)[this.getParty()].announcements()
-    );
+    return new Set<Announcement>(this.getParty().announcements());
   }
 
   possibleAnnouncements(): Set<Announcement> {

--- a/frontend/src/models/player.ts
+++ b/frontend/src/models/player.ts
@@ -172,8 +172,26 @@ export class Player {
     notifier.info("player-announced-" + announcement, { name: this.name });
   }
 
-  hasAnnounced(...announcements: Announcement[]) {
+  hasAnnounced(...announcements: Announcement[]): boolean {
     return announcements.every(a => [...this.announcements].includes(a));
+  }
+
+  wasAnnounced(...announcements: Announcement[]): boolean {
+    return announcements.every(a =>
+      [...this.announcements, ...this.getTeammateAnnouncements()].includes(a)
+    );
+  }
+
+  hasTeammateAnnounced(): boolean {
+    return this.getTeammateAnnouncements().size > 0;
+  }
+
+  getTeammateAnnouncements(): Set<Announcement> {
+    return (
+      this.game?.players.find(
+        player => this.id !== player.id && this.isRe() === player.isRe()
+      )?.announcements || new Set<Announcement>()
+    );
   }
 
   possibleAnnouncements(): Set<Announcement> {
@@ -184,10 +202,14 @@ export class Player {
     const announcements = getAnnouncementOrder(this.isRe());
     const cardBasedAllowedAnnouncements = announcements.slice(0, diff);
     const leftOverAnnouncements = announcements.slice(diff);
-    return this.hasAnnounced(...cardBasedAllowedAnnouncements)
+    return this.wasAnnounced(...cardBasedAllowedAnnouncements)
       ? new Set<Announcement>(
           leftOverAnnouncements.filter(
-            a => ![...this.announcements].includes(a)
+            a =>
+              ![
+                ...this.announcements,
+                ...this.getTeammateAnnouncements()
+              ].includes(a)
           )
         )
       : new Set<Announcement>();

--- a/frontend/tests/unit/models/player.test.ts
+++ b/frontend/tests/unit/models/player.test.ts
@@ -460,6 +460,16 @@ describe("announcements", () => {
     expect(player2.getTeammateAnnouncements()).toContain(Announcement.Re);
     expect(failingAnnouncement).toThrowError("Invalid announcement");
   });
+
+  test("should be able to announce after teammate", () => {
+    let player2 = game.players[1];
+    player.hand = aHandWith(9, queen.of(Suit.Clubs));
+    player2.hand = aHandWith(8, queen.of(Suit.Clubs));
+    player.announce(Announcement.Re);
+    player2.announce(Announcement.No90);
+
+    expect(player.getTeammateAnnouncements()).toContain(Announcement.No90);
+  });
 });
 
 function aHandWith(numberOfCards: number, ...cards: Card[]) {

--- a/frontend/tests/unit/models/player.test.ts
+++ b/frontend/tests/unit/models/player.test.ts
@@ -447,6 +447,19 @@ describe("announcements", () => {
 
     expect(possibleAnnouncements).toEqual(new Set());
   });
+
+  test("shouldn't be able to announce same as teammate", () => {
+    let player2 = game.players[1];
+    player.hand = aHandWith(9, queen.of(Suit.Clubs));
+    player2.hand = aHandWith(9, queen.of(Suit.Clubs));
+    player.announce(Announcement.Re);
+
+    let failingAnnouncement = () => player2.announce(Announcement.Re);
+
+    expect(player2.hasTeammateAnnounced(Announcement.Re)).toEqual(true);
+    expect(player2.getTeammateAnnouncements()).toContain(Announcement.Re);
+    expect(failingAnnouncement).toThrowError("Invalid announcement");
+  });
 });
 
 function aHandWith(numberOfCards: number, ...cards: Card[]) {

--- a/frontend/tests/unit/models/player.test.ts
+++ b/frontend/tests/unit/models/player.test.ts
@@ -456,8 +456,7 @@ describe("announcements", () => {
 
     let failingAnnouncement = () => player2.announce(Announcement.Re);
 
-    expect(player2.hasTeammateAnnounced(Announcement.Re)).toEqual(true);
-    expect(player2.getTeammateAnnouncements()).toContain(Announcement.Re);
+    expect(player2.possibleAnnouncements()).not.toContain(Announcement.Re);
     expect(failingAnnouncement).toThrowError("Invalid announcement");
   });
 
@@ -468,7 +467,7 @@ describe("announcements", () => {
     player.announce(Announcement.Re);
     player2.announce(Announcement.No90);
 
-    expect(player.getTeammateAnnouncements()).toContain(Announcement.No90);
+    expect(player.possibleAnnouncements()).not.toContain(Announcement.No90);
   });
 });
 


### PR DESCRIPTION
Removes already announced Announcements from your teammate from the `possibleannouncement()` function.
Hence it's not possible to announce the same as your teammate.

fixes #40 